### PR TITLE
added dependency of slurm_simulation.sh on slurm_scenarios

### DIFF
--- a/R/slurm.R
+++ b/R/slurm.R
@@ -8,6 +8,7 @@
 ##' @title Generate top section of SLURM script
 ##' @param jobName Name of the job
 ##' @param ntasks Number of tasks
+##' @param dependency Job ids completed after which execution should start
 ##' @param memCPU RAM per CPU
 ##' @param output Output file
 ##' @param error Error log file
@@ -15,8 +16,9 @@
 ##' @param time Maximum time
 ##' @param qos Quality of service
 ##' @keywords internal
-.slurmOptions <- function(jobName, ntasks = NULL, memCPU = NULL, output = NULL,
-                          error = NULL, array = NULL, time = NULL, qos = NULL) {
+.slurmOptions <- function(jobName, ntasks = NULL, dependency = NULL, memCPU = NULL, 
+                          output = NULL, error = NULL, array = NULL, time = NULL, 
+                          qos = NULL) {
   ## Header and job name
   paste0(
     "#!/bin/bash", "\n",
@@ -24,6 +26,9 @@
     ## Number of tasks per CPU
     if (!is.null(ntasks)) {
       paste0("#SBATCH --ntasks=", ntasks, "\n")
+    },
+    if (!is.null(dependency)) {
+      paste0("#SBATCH --dependency=singleton --job-name=", dependency, "\n")
     },
     ## RAM per CPU
     if (!is.null(memCPU)) {
@@ -56,6 +61,7 @@
 ##' @title Write SLURM script to file
 ##' @param jobName Name of the job
 ##' @param ntasks Number of tasks
+##' @param dependency Job ids completed after which execution should start
 ##' @param memCPU RAM per CPU
 ##' @param output Output file
 ##' @param error Error log file
@@ -64,14 +70,15 @@
 ##' @param qos Quality of service
 ##' @param pre List of commands before main command
 ##' @param cmd Main command
-##' @param post List of commands after mein command
+##' @param post List of commands after main command
 ##' @param file Filename
 ##' @keywords internal
-.writeSlurm <- function(jobName, ntasks = NULL, memCPU = NULL, output = NULL,
-                        error = NULL, array = NULL, time = NULL, qos = NULL,
-                        pre = NULL, cmd = NULL, post = NULL, file = NULL) {
+.writeSlurm <- function(jobName, ntasks = NULL, dependency =NULL, memCPU = NULL, 
+                        output = NULL, error = NULL, array = NULL, time = NULL, 
+                        qos = NULL, pre = NULL, cmd = NULL, post = NULL, 
+                        file = NULL) {
   cat(
-    .slurmOptions(jobName, ntasks, memCPU, output, error, array, time, qos),
+    .slurmOptions(jobName, ntasks, dependency, memCPU, output, error, array, time, qos),
     if (!is.null(array)) {
       paste0("ID=$(expr ${SLURM_ARRAY_TASK_ID} - 0)", "\n")
     },

--- a/R/slurm.R
+++ b/R/slurm.R
@@ -16,8 +16,8 @@
 ##' @param time Maximum time
 ##' @param qos Quality of service
 ##' @keywords internal
-.slurmOptions <- function(jobName, ntasks = NULL, dependency = NULL, memCPU = NULL, 
-                          output = NULL, error = NULL, array = NULL, time = NULL, 
+.slurmOptions <- function(jobName, ntasks = NULL, dependency = NULL, memCPU = NULL,
+                          output = NULL, error = NULL, array = NULL, time = NULL,
                           qos = NULL) {
   ## Header and job name
   paste0(
@@ -73,9 +73,9 @@
 ##' @param post List of commands after main command
 ##' @param file Filename
 ##' @keywords internal
-.writeSlurm <- function(jobName, ntasks = NULL, dependency =NULL, memCPU = NULL, 
-                        output = NULL, error = NULL, array = NULL, time = NULL, 
-                        qos = NULL, pre = NULL, cmd = NULL, post = NULL, 
+.writeSlurm <- function(jobName, ntasks = NULL, dependency = NULL, memCPU = NULL,
+                        output = NULL, error = NULL, array = NULL, time = NULL,
+                        qos = NULL, pre = NULL, cmd = NULL, post = NULL,
                         file = NULL) {
   cat(
     .slurmOptions(jobName, ntasks, dependency, memCPU, output, error, array, time, qos),

--- a/R/slurm_scenarios.R
+++ b/R/slurm_scenarios.R
@@ -28,6 +28,7 @@ slurmPrepareScenarios <- function(expName, scenarios, full, bSize = 200,
 
   ## Store into cache
   temp <- list(
+    expName = expName,
     scen_batches = batches,
     scen_nbatches = nbatches
   )

--- a/R/slurm_simulation.R
+++ b/R/slurm_simulation.R
@@ -10,12 +10,14 @@
 ##' @param expName Name of experiment
 ##' @param scenarios Scenario data frame
 ##' @param ntasks Number of tasks per CPU
+##' @param dep Should slurm_simulation.sh be launched only once 
+##' slurm_scenarios.sh has been completed
 ##' @param memCPU Memory per CPU
 ##' @param time Maximum time
 ##' @param qos Quality of service
 ##' @export
 slurmPrepareRunScenarios <- function(expName, scenarios = NULL, ntasks = 1,
-                                     memCPU = "250MB", time = "06:00:00",
+                                     dep = T, memCPU = "250MB", time = "06:00:00",
                                      qos = "6hours") {
   ## Appease NSE notes in R CMD check
   scens <- NULL
@@ -27,6 +29,7 @@ slurmPrepareRunScenarios <- function(expName, scenarios = NULL, ntasks = 1,
     scenarios <- scens
   }
 
+  
   ## Create a submission script
   filename <- file.path(
     get(x = "experimentDir", envir = .pkgcache), "slurm_simulation.sh"
@@ -34,6 +37,7 @@ slurmPrepareRunScenarios <- function(expName, scenarios = NULL, ntasks = 1,
   .writeSlurm(
     jobName = paste0(expName, "_simulation"),
     ntasks = ntasks,
+    dependency = ifelse(dep,paste0(expName, "_scenarios"),NULL),
     array = nrow(scenarios),
     time = time,
     qos = qos,

--- a/R/slurm_simulation.R
+++ b/R/slurm_simulation.R
@@ -10,15 +10,15 @@
 ##' @param expName Name of experiment
 ##' @param scenarios Scenario data frame
 ##' @param ntasks Number of tasks per CPU
-##' @param dep Should slurm_simulation.sh be launched only once 
+##' @param dep Should slurm_simulation.sh be launched only once
 ##' slurm_scenarios.sh has been completed
 ##' @param memCPU Memory per CPU
 ##' @param time Maximum time
 ##' @param qos Quality of service
 ##' @export
 slurmPrepareRunScenarios <- function(expName, scenarios = NULL, ntasks = 1,
-                                     dep = T, memCPU = "250MB", time = "06:00:00",
-                                     qos = "6hours") {
+                                     dep = TRUE, memCPU = "250MB",
+                                     time = "06:00:00", qos = "6hours") {
   ## Appease NSE notes in R CMD check
   scens <- NULL
 
@@ -29,7 +29,7 @@ slurmPrepareRunScenarios <- function(expName, scenarios = NULL, ntasks = 1,
     scenarios <- scens
   }
 
-  
+
   ## Create a submission script
   filename <- file.path(
     get(x = "experimentDir", envir = .pkgcache), "slurm_simulation.sh"
@@ -37,7 +37,7 @@ slurmPrepareRunScenarios <- function(expName, scenarios = NULL, ntasks = 1,
   .writeSlurm(
     jobName = paste0(expName, "_simulation"),
     ntasks = ntasks,
-    dependency = ifelse(dep,paste0(expName, "_scenarios"),NULL),
+    dependency = ifelse(dep, paste0(expName, "_scenarios"), NULL),
     array = nrow(scenarios),
     time = time,
     qos = qos,

--- a/man/dot-slurmOptions.Rd
+++ b/man/dot-slurmOptions.Rd
@@ -7,6 +7,7 @@
 .slurmOptions(
   jobName,
   ntasks = NULL,
+  dependency = NULL,
   memCPU = NULL,
   output = NULL,
   error = NULL,
@@ -19,6 +20,8 @@
 \item{jobName}{Name of the job}
 
 \item{ntasks}{Number of tasks}
+
+\item{dependency}{Job ids completed after which execution should start}
 
 \item{memCPU}{RAM per CPU}
 

--- a/man/dot-writeSlurm.Rd
+++ b/man/dot-writeSlurm.Rd
@@ -7,6 +7,7 @@
 .writeSlurm(
   jobName,
   ntasks = NULL,
+  dependency = NULL,
   memCPU = NULL,
   output = NULL,
   error = NULL,
@@ -24,6 +25,8 @@
 
 \item{ntasks}{Number of tasks}
 
+\item{dependency}{Job ids completed after which execution should start}
+
 \item{memCPU}{RAM per CPU}
 
 \item{output}{Output file}
@@ -40,7 +43,7 @@
 
 \item{cmd}{Main command}
 
-\item{post}{List of commands after mein command}
+\item{post}{List of commands after main command}
 
 \item{file}{Filename}
 }

--- a/man/slurmPrepareRunScenarios.Rd
+++ b/man/slurmPrepareRunScenarios.Rd
@@ -8,7 +8,7 @@ slurmPrepareRunScenarios(
   expName,
   scenarios = NULL,
   ntasks = 1,
-  dep = T,
+  dep = TRUE,
   memCPU = "250MB",
   time = "06:00:00",
   qos = "6hours"

--- a/man/slurmPrepareRunScenarios.Rd
+++ b/man/slurmPrepareRunScenarios.Rd
@@ -8,6 +8,7 @@ slurmPrepareRunScenarios(
   expName,
   scenarios = NULL,
   ntasks = 1,
+  dep = T,
   memCPU = "250MB",
   time = "06:00:00",
   qos = "6hours"
@@ -19,6 +20,9 @@ slurmPrepareRunScenarios(
 \item{scenarios}{Scenario data frame}
 
 \item{ntasks}{Number of tasks per CPU}
+
+\item{dep}{Should slurm_simulation.sh be launched only once
+slurm_scenarios.sh has been completed}
 
 \item{memCPU}{Memory per CPU}
 

--- a/tests/testthat/test-slurm_simulation.R
+++ b/tests/testthat/test-slurm_simulation.R
@@ -11,6 +11,7 @@ test_that("slurmPrepareRunScenarios works", {
   expected <- paste(capture.output(cat("#!/bin/bash
 #SBATCH --job-name=test_simulation
 #SBATCH --ntasks=1
+#SBATCH --dependency=singleton --job-name=test_scenarios
 #SBATCH --output=", dir, "/logs/simulation/test_simulation_%A_%a.log
 #SBATCH --error=", dir, "/logs/simulation/test_simulation_%A_%a_error.log
 #SBATCH --array=1-450


### PR DESCRIPTION
Hi
When you launch big experiments, your scenario creation might take a while, and when submitting the same time slurm_simulation you might run into errors, where slurm_simulation is looking for scenario files that have not yet been created.
I added SBATCH --dependency=singleton --job-name=your_experiment_name to avoid this issue...

