### PR TITLE
updated omOutputdict based on parsing openMalaria reporters

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -104,6 +104,134 @@ FOREIGN KEY (experiment_id, scenario_id) REFERENCES scenarios (experiment_id, sc
 }
 
 ##' @title Open Malaria output dictionary
+##' @description A dictionary which provides translations for the following
+##'   outputs of Open Malaria:
+##'
+##'   - Survey measure numbers to names
+##'
+##'   - Whether measures values are summed events between survey dates 
+##'   (measure_tally = TRUE) or taken on the survey date (measure_tally=F)
+##'
+##'   - An identifier for the 'third dimension' column. This can be 'age_group',
+##' 'vector_species', 'drug_id' or NA
+##' See: https://github.com/SwissTPH/openmalaria/wiki/MonitoringOptions
+##' @export
+omOutputDict  <- function() {
+  dict <- data.table::data.table(
+    measure_index = as.integer(c(
+      0, 1, 2, 3, 4, 5, 6, 7, 8,
+      10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      20, 21, 22, 23, 24, 25, 26, 27,
+      30, 31, 32, 33, 34, 35, 36, 39,
+      40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+      50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
+      60, 61, 62, 63, 64, 65, 66, 67, 68, 69,
+      70, 71, 72, 73, 74, 75, 76, 77, 78, 79
+    )),
+    measure_name  = c(
+      ## 0 - 8
+      "nHost", "nInfect", "nExpectd", "nPatent", "sumLogPyrogenThres",
+      "sumlogDens", "totalInfs", "nTransmit", "totalPatentInf",
+      
+      ## 10s
+      "sumPyrogenThresh", "nTreatments1", "nTreatments2", "nTreatments3",
+      "nUncomp", "nSevere", "nSeq", "nHospitalDeaths", "nIndDeaths",
+      "nDirDeaths",
+      
+      ## 20s
+      "nEPIVaccinations", "allCauseIMR", "nMassVaccinations", "nHospitalRecovs",
+      "nHospitalSeqs", "nIPTDoses", "annAvgK", "nNMFever",
+      
+      ## 30s
+      "innoculationsPerAgeGroup", "Vector_Nv0", "Vector_Nv", "Vector_Ov",
+      "Vector_Sv", "inputEIR", "simulatedEIR", "Clinical_RDTs",
+      
+      ## 40s
+      "Clinical_DrugUsage", "Clinical_FirstDayDeaths",
+      "Clinical_HospitalFirstDayDeaths", "nNewefections", "nMassITNs",
+      "nEPI_ITNs", "nMassIRS", "nMassVA", "Clinical_Microscopy",
+      "Clinical_DrugUsageIV",
+      
+      ## 50s
+      "nAddedToCohort", "nRemovedFromCohort", "nMDAs", "nNmfDeaths",
+      "nAntibioticTreatments", "nMassScreenings", "nMassGVI", "nCtsIRS",
+      "nCtsGVI", "nCtsMDA",
+      
+      ## 60s
+      "nCtsScreenings", "nSubPopRemovalTooOld", "nSubPopRemovalFirstEvent",
+      "nLiverStageTreatments", "nTreatDiagnostics", "nMassRecruitOnly",
+      "nCtsRecruitOnly", "nTreatDeployments", "sumAge", "nInfectByGenotype",
+      
+      ## 70s
+      "nPatentByGenotype", "logDensByGenotype", "nHostDrugConcNonZero",
+      "sumLogDrugConcNonZero", "expectedDirectDeaths", "expectedHospitalDeaths",
+      "expectedIndirectDeaths", "expectedSequelae", "expectedSevere",
+      "innoculationsPerVector"
+    ),
+    measure_tally = c(
+      ## 0 - 8
+      FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
+      
+      ## 10s
+      FALSE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
+      
+      ## 20s
+      TRUE, NA, TRUE, TRUE, TRUE, NA, FALSE, TRUE,
+      
+      ## 30s
+      FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, NA,
+      
+      ## 40s
+      NA, TRUE, TRUE, NA, TRUE, TRUE, TRUE, NA, NA, NA,
+      
+      ## 50s
+      NA, NA, TRUE, TRUE, NA, TRUE, TRUE, TRUE, TRUE, TRUE,
+      
+      ## 60s
+      TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, NA, FALSE, FALSE,
+      
+      ## 70s
+      FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE
+    ),
+    third_dimension = c(
+      ## 0 - 8
+      "age_group","age_group","age_group","age_group","age_group",
+      "age_group","age_group",NA,"age_group",
+      
+      ## 10s
+      "age_group","age_group","age_group","age_group","age_group",
+      "age_group","age_group","age_group","age_group","age_group",
+      
+      ## 20s
+      "age_group",NA,"age_group","age_group","age_group","age_group",
+      NA,"age_group",
+      
+      ## 30s
+      "age_group","vector_species","vector_species","vector_species",
+      "vector_species",NA,NA,NA,
+      
+      ## 40s
+      "drug_id","age_group","age_group","age_group","age_group","age_group",
+      "age_group","age_group",NA,"drug_id",
+      
+      ## 50s
+      "age_group","age_group","age_group","age_group","age_group",
+      "age_group","age_group","age_group","age_group","age_group",
+      
+      ## 60s
+      "age_group","age_group","age_group","age_group","age_group",
+      "age_group","age_group","age_group","age_group","age_group",
+      
+      ## 70s
+      "age_group","age_group","age_group","age_group","age_group",
+      "age_group","age_group","age_group","age_group",NA
+    )
+  )
+  return(dict)
+}
+
+
+##' @title Open Malaria output dictionary
 ##' @description A dictionary which provides tranlations for the following
 ##'   outputs of Open Malaria:
 ##'


### PR DESCRIPTION
Update to the output dictionary translating output numbers to names, also distinguishing whether measure values are summed between two surveys (measure_tally=T) or whether taken on survey point (measure_tally=F).

To parse survey output measure names and tally property from openMalaria v44.0 source code, do:

grep -oP '\[\K[^\]]+' model/mon/OutputMeasures.h > tmp1.txt ;
grep 'OutMeasure::' model/mon/OutputMeasures.h | cut -d, -f 2 > tmp2.txt
cat tmp2.txt | while read line;do grep -r "mon::$line" model/Host model/interventions/ model/Clinical model/Transmission model/PkPd | grep -Po 'report\K[^(]*' | paste -s -d, - >> tmp3.txt;done
paste tmp*.txt > surveyMeasureTable.txt
rm tmp*.txt

The  third column surveyMeasureTable file contains the report property, everything containing "Stat" is translated as measure_tally=F in the dictionary.
