### PR TITLE
corrected values for incident column in omOutputDict

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -171,28 +171,28 @@ omOutputDict <- function() {
     ),
     incident = c(
       ## 0 - 8
-      TRUE, TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, NA, NA,
-
+      FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
+      
       ## 10s
       FALSE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
-
+      
       ## 20s
-      TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, TRUE,
-
+      TRUE, NA, TRUE, TRUE, TRUE, NA, FALSE, TRUE,
+      
       ## 30s
-      TRUE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, TRUE,
-
+      FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, NA,
+      
       ## 40s
-      NA, NA, NA, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
-
+      NA, TRUE, TRUE, NA, TRUE, TRUE, TRUE, NA, NA, NA,
+      
       ## 50s
-      TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
-
+      NA, NA, TRUE, TRUE, NA, TRUE, TRUE, TRUE, TRUE, TRUE,
+      
       ## 60s
-      TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, TRUE,
-
+      TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, NA, FALSE, FALSE,
+      
       ## 70s
-      TRUE, FALSE, TRUE, NA, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE
+      FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE
     ),
     third_dimension = c(
       ## 0 - 8

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -100,28 +100,28 @@ test_that("omOutputDict works", {
     ),
     incident = c(
       ## 0 - 8
-      TRUE, TRUE, TRUE, TRUE, FALSE, FALSE, FALSE, NA, NA,
-
+      FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE,
+      
       ## 10s
       FALSE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
-
+      
       ## 20s
-      TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, TRUE,
-
+      TRUE, NA, TRUE, TRUE, TRUE, NA, FALSE, TRUE,
+      
       ## 30s
-      TRUE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, TRUE,
-
+      FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, NA,
+      
       ## 40s
-      NA, NA, NA, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
-
+      NA, TRUE, TRUE, NA, TRUE, TRUE, TRUE, NA, NA, NA,
+      
       ## 50s
-      TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE,
-
+      NA, NA, TRUE, TRUE, NA, TRUE, TRUE, TRUE, TRUE, TRUE,
+      
       ## 60s
-      TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, TRUE,
-
+      TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, NA, FALSE, FALSE,
+      
       ## 70s
-      TRUE, FALSE, TRUE, NA, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE
+      FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE
     ),
     third_dimension = c(
       ## 0 - 8


### PR DESCRIPTION
To parse measure names from openMalaria v44.0 source code:

grep -oP '[\K[^\]]+' model/mon/OutputMeasures.h > tmp1.txt ;
grep 'OutMeasure::' model/mon/OutputMeasures.h | cut -d, -f 2 > tmp2.txt
cat tmp2.txt | while read line;do grep -r "mon::$line" model/Host model/interventions/ model/Clinical model/Transmission model/PkPd | grep -Po 'report\K[^(]' | paste -s -d, - >> tmp3.txt;done
paste tmp.txt > surveyMeasureTable.txt
rm tmp*.txt

The third column in surveyMeasureTable corresponds to whether reporting is summing events ("Event" strings, measure_tally=T) or not ("Stat" strings, measure_tally=F).
